### PR TITLE
Add editor tools & vim-duckscript link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 * [Duckscript Embedding Tutorial](#embed-tutorial)
     * [Setting Up The Context](#embed-tutorial-setup-context)
     * [Running The Script](#embed-tutorial-running)
+* [Editor Support](#editor-support)
 * [Contributing](#contributing)
 * [Release History](https://github.com/sagiegurari/duckscript/blob/master/CHANGELOG.md)
 * [License](#license)
@@ -541,6 +542,10 @@ pub fn run_script(text: &str, context: Context) -> Result<Context, ScriptError>;
 /// Executes the provided script file with the given context
 pub fn run_script_file(file: &str, context: Context) -> Result<Context, ScriptError>;
 ```
+
+<a name="editor-support"></a>
+## Editor Support
+* Vim: [vim-duckscript](https://github.com/nastevens/vim-duckscript)
 
 <a name="contributing"></a>
 ## Contributing

--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -499,6 +499,10 @@ pub fn run_script(text: &str, context: Context) -> Result<Context, ScriptError>;
 pub fn run_script_file(file: &str, context: Context) -> Result<Context, ScriptError>;
 ```
 
+<a name="editor-support"></a>
+## Editor Support
+* Vim: [vim-duckscript](https://github.com/nastevens/vim-duckscript)
+
 <a name="contributing"></a>
 ## Contributing
 There are many ways to contribute to duckscript, including:

--- a/docs/_includes/nav.md
+++ b/docs/_includes/nav.md
@@ -25,6 +25,7 @@
 * [Duckscript Embedding Tutorial](#embed-tutorial)
     * [Setting Up The Context](#embed-tutorial-setup-context)
     * [Running The Script](#embed-tutorial-running)
+* [Editor Support](#editor-support)
 * [Contributing](#contributing)
 * [Release History](https://github.com/sagiegurari/duckscript/blob/master/CHANGELOG.md)
 * [License](#license)


### PR DESCRIPTION
Sorry for the bit of self-promotion, but I wrote a [vim syntax highlighter for duckscript](https://github.com/nastevens/vim-duckscript) and thought it might be generally useful. I would totally understand if you don't want to add external links to your documentation.