### PR TITLE
PKGBUILD file for ArchUserRepo submission

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -6,7 +6,7 @@ pkgbase = duckscript
 	arch = x86_64
 	license = Apache
 	makedepends = cargo
-	source = duckscript-0.8.20.tar.gz::https://github.com/sagiegurari/duckscript/archive/refs/tags/0.8.20.tar.gz
+	source = duckscript-0.8.20.tar.gz::https://github.com/sagiegurari/duckscript/archive/0.8.20.tar.gz
 	sha512sums = 7ffe4ad2d1bb54753d7c262981bf31394404dd71a75919188a5f658de39b9b9215d057da382e220433d866369417e74feaef3ab4ac80df5214b046284f5f840d
 	b2sums = 869859f0d7e21abf1f3e1041e6f7056c25d4e6341bab19788c95c609da60cff5add66ec113aa1f2ff9557596537728a6255ec65c280668d9d3e8e785d042f616
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,0 +1,13 @@
+pkgbase = duckscript
+	pkgdesc = Simple, extendable and embeddable scripting language.
+	pkgver = 0.8.20
+	pkgrel = 1
+	url = https://sagiegurari.github.io/duckscript/
+	arch = x86_64
+	license = Apache
+	makedepends = cargo
+	source = duckscript-0.8.20.tar.gz::https://github.com/sagiegurari/duckscript/archive/refs/tags/0.8.20.tar.gz
+	sha512sums = 7ffe4ad2d1bb54753d7c262981bf31394404dd71a75919188a5f658de39b9b9215d057da382e220433d866369417e74feaef3ab4ac80df5214b046284f5f840d
+	b2sums = 869859f0d7e21abf1f3e1041e6f7056c25d4e6341bab19788c95c609da60cff5add66ec113aa1f2ff9557596537728a6255ec65c280668d9d3e8e785d042f616
+
+pkgname = duckscript

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,13 +22,14 @@ b2sums=("869859f0d7e21abf1f3e1041e6f7056c25d4e6341bab19788c95c609da60cff5add66ec
 
 prepare(){
 	export RUSTUP_TOOLCHAIN=stable
-	cargo fetch --locked --target "$arch-unknown-linux-gnu"
+	cargo fetch --locked
 }
 
 build(){
 	cd "$pkgname-$pkgver"
 	export RUSTUP_TOOLCHAIN=stable
-	cargo build --frozen --workspace --release --all-features --target-dir target --target "$arch-unknown-linux-gnu" 
+	export CARGO_TARGET_DIR=target
+	cargo build --frozen --workspace --release --all-features
 }
 
 check(){

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -36,10 +36,12 @@ check(){
 	cd "$pkgname-$pkgver"
 	export RUSTUP_TOOLCHAIN=stable
 	cargo test --frozen --workspace --all-features
+	cargo test --frozen --workspace --all-features -- --ignored --test-threads=1
 } 
 
 package(){
 	install --verbose -D --mode 755 --target-directory "$pkgdir/usr/bin" "$pkgname-$pkgver/target/release/duck"
-	install --verbose -D --mode 644 --target-directory "$pkgdir/usr/share/licenses/$pkgname" LICENSE
-	install --verbose -D --mode 644 --target-directory "$pkgdir/usr/share/doc/$pkgname" *.md
+	install --verbose -D --mode 644 --target-directory "$pkgdir/usr/share/licenses/$pkgname" "$pkgname-$pkgver/LICENSE"
+	install --verbose -D --mode 644 --target-directory "$pkgdir/usr/share/doc/$pkgname" "$pkgname-$pkgver/CHANGELOG.md"
+	install --verbose -D --mode 644 --target-directory "$pkgdir/usr/share/doc/$pkgname" "$pkgname-$pkgver/README.md"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: Cosmin Gabriel Georgescu <cosmingg2013@gmail.com>
+pkgname="duckscript"
+pkgver=0.8.20
+pkgrel=1
+pkgdesc="Simple, extendable and embeddable scripting language."
+
+# https://github.com/sagiegurari/duckscript#installation-binary-release
+arch=("x86_64")
+
+url="https://sagiegurari.github.io/duckscript/"
+
+# https://github.com/sagiegurari/duckscript/blob/master/LICENSE
+license=("Apache")
+
+makedepends=("cargo")
+
+source=("$pkgname-$pkgver.tar.gz::https://github.com/sagiegurari/duckscript/archive/refs/tags/$pkgver.tar.gz")
+
+sha512sums=("7ffe4ad2d1bb54753d7c262981bf31394404dd71a75919188a5f658de39b9b9215d057da382e220433d866369417e74feaef3ab4ac80df5214b046284f5f840d")
+
+b2sums=("869859f0d7e21abf1f3e1041e6f7056c25d4e6341bab19788c95c609da60cff5add66ec113aa1f2ff9557596537728a6255ec65c280668d9d3e8e785d042f616")
+
+build(){
+	cd "$pkgname-$pkgver"
+	export RUSTUP_TOOLCHAIN=stable
+	cargo build --locked --workspace --release --all-features --target-dir target --target "$arch-unknown-linux-gnu"
+}
+
+check(){
+	cd "$pkgname-$pkgver"
+	export RUSTUP_TOOLCHAIN=stable
+	cargo test --frozen --workspace --all-features --target "$arch-unknown-linux-gnu"
+} 
+
+package(){
+	install -D --mode 755 --target-directory "$pkgdir/usr/bin" "$pkgname-$pkgver/target/release/duck"
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -20,16 +20,21 @@ sha512sums=("7ffe4ad2d1bb54753d7c262981bf31394404dd71a75919188a5f658de39b9b9215d
 
 b2sums=("869859f0d7e21abf1f3e1041e6f7056c25d4e6341bab19788c95c609da60cff5add66ec113aa1f2ff9557596537728a6255ec65c280668d9d3e8e785d042f616")
 
+prepare(){
+	export RUSTUP_TOOLCHAIN=stable
+	cargo fetch --locked --target "$arch-unknown-linux-gnu"
+}
+
 build(){
 	cd "$pkgname-$pkgver"
 	export RUSTUP_TOOLCHAIN=stable
-	cargo build --locked --workspace --release --all-features --target-dir target --target "$arch-unknown-linux-gnu"
+	cargo build --frozen --workspace --release --all-features --target-dir target --target "$arch-unknown-linux-gnu" 
 }
 
 check(){
 	cd "$pkgname-$pkgver"
 	export RUSTUP_TOOLCHAIN=stable
-	cargo test --frozen --workspace --all-features --target "$arch-unknown-linux-gnu"
+	cargo test --frozen --workspace --all-features
 } 
 
 package(){

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,7 +14,7 @@ license=("Apache")
 
 makedepends=("cargo")
 
-source=("$pkgname-$pkgver.tar.gz::https://github.com/sagiegurari/duckscript/archive/refs/tags/$pkgver.tar.gz")
+source=("$pkgname-$pkgver.tar.gz::https://github.com/sagiegurari/duckscript/archive/$pkgver.tar.gz")
 
 sha512sums=("7ffe4ad2d1bb54753d7c262981bf31394404dd71a75919188a5f658de39b9b9215d057da382e220433d866369417e74feaef3ab4ac80df5214b046284f5f840d")
 
@@ -22,7 +22,7 @@ b2sums=("869859f0d7e21abf1f3e1041e6f7056c25d4e6341bab19788c95c609da60cff5add66ec
 
 prepare(){
 	export RUSTUP_TOOLCHAIN=stable
-	cargo fetch --locked
+	cargo fetch --locked --target "$arch-unknown-linux-gnu"
 }
 
 build(){
@@ -39,5 +39,7 @@ check(){
 } 
 
 package(){
-	install -D --mode 755 --target-directory "$pkgdir/usr/bin" "$pkgname-$pkgver/target/release/duck"
+	install --verbose -D --mode 755 --target-directory "$pkgdir/usr/bin" "$pkgname-$pkgver/target/release/duck"
+	install --verbose -D --mode 644 --target-directory "$pkgdir/usr/share/licenses/$pkgname" LICENSE
+	install --verbose -D --mode 644 --target-directory "$pkgdir/usr/share/doc/$pkgname" *.md
 }


### PR DESCRIPTION
As someone suggested in [this issue](https://github.com/sagiegurari/duckscript/issues/274), I've added the PKGBUILD file and necessary for submitting to the Arch User Repository. 

&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, if you will merge PR, users will be able to just `makepkg -ci` inside the cloned directory and build the package locally followed by a `pacman -U` installation, though, since `cargo` is a make dependency and they will have already cloned the repo, it is of questionable use as they could just take the `cargo install` route.

&nbsp;&nbsp;&nbsp;&nbsp;Just wanted to check in with you regarding the project building and everything before submitting the file to AUR. As per [check() doc](https://wiki.archlinux.org/title/creating_packages#check()), this function could be removed. Since this a release package, this function currently serves to locally check that you did not release a broken version. I would remove it as it decreases installation time with little to no dangers, let me know what you think.